### PR TITLE
WebUI: Revert unselectable General-tab

### DIFF
--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -1,4 +1,4 @@
-<div id="propGeneral" class="propertiesTabContent invisible unselectable">
+<div id="propGeneral" class="propertiesTabContent invisible">
     <div id="propProgressWrapper">
         <span>QBT_TR(Progress:)QBT_TR[CONTEXT=PropertiesWidget]</span>
         <span id="progress"></span>


### PR DESCRIPTION
Making General-tab text `unselectable` is not an improvement.

It begs to add a new `Copy -> Save path` feature, because using `Set location` to copy save path (*which requires a request*) is not faster than simply copying it from the `General` tab by double-left clicking and pressing `CTRL+C`.

I don't see a reason why its necessary to software-restrict people from copying details from the `General`-tab - there are several reasons why you would - incl. the above mentioned usecase for quickly copying save-path, but other than that its counterproductive to limit people from copying the details displayed.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
